### PR TITLE
Migrated to MySQL Functions ST_Dimension and ST_GeomFromText

### DIFF
--- a/sql/buffer_point.sql
+++ b/sql/buffer_point.sql
@@ -63,7 +63,7 @@ BEGIN
 	SET polygonstring = concat(polygonstring,firstcoords, '))');
 
 	-- Turn it into geometry and return it
-	RETURN GeomFromText(polygonstring);
+	RETURN ST_GeomFromText(polygonstring);
 
 END$$
 DELIMITER ;

--- a/sql/point_bearing_distance.sql
+++ b/sql/point_bearing_distance.sql
@@ -42,7 +42,7 @@ BEGIN
 
 	DECLARE secondpoint TEXT;
 	SET secondpoint = CONCAT('POINT(', wp_point_bearing_distance_coord_pair(p,bearing,distance,eradius), ')');
-	RETURN LineString(p, GeomFromText(secondpoint) );
+	RETURN LineString(p, ST_GeomFromText(secondpoint) );
 END$$
 
 

--- a/test/tests/QueryOrderByDistance.php
+++ b/test/tests/QueryOrderByDistance.php
@@ -35,7 +35,7 @@ if ( ! $wpq->have_posts() ) {
 	while ( $wpq->have_posts() ) {
 		$wpq->the_post();
 		$post_id = get_the_ID();
-		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT ST_Distance( meta_value, GeomFromText( \'POLYGON ((-1.26 1.08, -1.26 1.09, -1.21 1.09, -1.21 1.08, -1.26 1.08))\', 4326)) FROM ' . $wpdb->postmeta . '_geo WHERE post_id=%s', array( $post_id ) ) );
+		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT ST_Distance( meta_value, ST_GeomFromText( \'POLYGON ((-1.26 1.08, -1.26 1.09, -1.21 1.09, -1.21 1.08, -1.26 1.08))\', 4326, \'axis-order=long-lat\')) FROM ' . $wpdb->postmeta . '_geo WHERE post_id=%s', array( $post_id ) ) );
 
 		if ( $res < $maxVal ) {
 			fail( $wpq );
@@ -70,7 +70,7 @@ if ( ! $wpq->have_posts() ) {
 	while ( $wpq->have_posts() ) {
 		$wpq->the_post();
 		$post_id = get_the_ID();
-		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT ST_Distance( meta_value, GeomFromText( \'POLYGON ((-1.26 1.08, -1.26 1.09, -1.21 1.09, -1.21 1.08, -1.26 1.08))\', 4326)) FROM ' . $wpdb->postmeta . '_geo WHERE post_id=%s', array( $post_id ) ) );
+		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT ST_Distance( meta_value, ST_GeomFromText( \'POLYGON ((-1.26 1.08, -1.26 1.09, -1.21 1.09, -1.21 1.08, -1.26 1.08))\', 4326, \'axis-order=long-lat\')) FROM ' . $wpdb->postmeta . '_geo WHERE post_id=%s', array( $post_id ) ) );
 
 		if ( $res > $minVal) {
 			fail( $wpq );

--- a/test/tests/QueryOrderByTest.php
+++ b/test/tests/QueryOrderByTest.php
@@ -106,7 +106,7 @@ if ( ! $wpq->have_posts() ) {
 	while ( $wpq->have_posts() ) {
 		$wpq->the_post();
 		$post_id = get_the_ID();
-		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT Dimension(meta_value) FROM ' . $wpdb->postmeta . '_geo WHERE meta_key=\'wpgeometa_test\' AND post_id=%s', array( $post_id ) ) );
+		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT ST_Dimension(meta_value) FROM ' . $wpdb->postmeta . '_geo WHERE meta_key=\'wpgeometa_test\' AND post_id=%s', array( $post_id ) ) );
 
 		if ( $res > $minVal) {
 			fail( $wpq );
@@ -147,7 +147,7 @@ if ( ! $wpq->have_posts() ) {
 	while ( $wpq->have_posts() ) {
 		$wpq->the_post();
 		$post_id = get_the_ID();
-		$res = $wpdb->get_var( $wpdb->prepare( 'SELECT Dimension(meta_value) FROM ' . $wpdb->postmeta . '_geo WHERE meta_key=\'wpgeometa_test\' AND post_id=%s', array( $post_id ) ) );
+		$res = $wpdb->get_var( $wpdb->prepare( 'ST_Dimension (meta_value) FROM ' . $wpdb->postmeta . '_geo WHERE meta_key=\'wpgeometa_test\' AND post_id=%s', array( $post_id ) ) );
 
 		if ( $res < $maxVal) {
 			fail( $wpq );

--- a/wp-geometa.php
+++ b/wp-geometa.php
@@ -762,10 +762,12 @@ if ( !class_exists( 'WP_GeoMeta', false ) ) {
 			$the_other_field = ( $thepair['lat'] === $meta_key ? $thepair['lng'] : $thepair['lat'] );
 
 			$meta = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE {$type}_id = %d AND meta_key = %s", array( $object_id, $the_other_field ) ), ARRAY_A ); // @codingStandardsIgnoreLine
-
+			
 			$id_column = ( 'user' === $type ) ? 'umeta_id' : 'meta_id';
-
-			$meta_ids[] = $meta[ $id_column ];
+			
+			if(is_array($meta) && array_key_exists($id_column, $meta)) {
+				$meta_ids[] = $meta[ $id_column ];
+			}
 
 			return $meta_ids;
 		}

--- a/wp-geometa.php
+++ b/wp-geometa.php
@@ -454,8 +454,8 @@ if ( !class_exists( 'WP_GeoMeta', false ) ) {
 			%d,
 			%d,
 			%s,
-			GeomFromText(%s,%d)
-		) ON DUPLICATE KEY UPDATE meta_value=GeomFromText(%s,%d)",
+			ST_GeomFromText(%s,%d, 'axis-order=long-lat')
+		) ON DUPLICATE KEY UPDATE meta_value=ST_GeomFromText(%s,%d, 'axis-order=long-lat')",
 					array(
 						$object_id,
 						$meta_id,

--- a/wp-geoquery.php
+++ b/wp-geoquery.php
@@ -164,8 +164,8 @@ if ( !class_exists( 'WP_GeoQuery', false ) ) {
 			 *
 			 * Needs to become
 			 *
-			 * INNER JOIN ( SELECT meta_key, Dimension(meta_value) AS meta_value FROM wp_postmeta_geo ) wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id)
-			 * INNER JOIN ( SELECT meta_key, ST_DISTANCE(meta_value, GeomFromText('POINT(0,0)')) AS meta_value FROM wp_postmeta_geo ) mt1 ON ( wp_posts.ID = mt1.post_id )
+			 * INNER JOIN ( SELECT meta_key, ST_Dimension(meta_value) AS meta_value FROM wp_postmeta_geo ) wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id)
+			 * INNER JOIN ( SELECT meta_key, ST_DISTANCE(meta_value, ST_GeomFromText('POINT(0,0)')) AS meta_value FROM wp_postmeta_geo ) mt1 ON ( wp_posts.ID = mt1.post_id )
 			 *
 			 */
 
@@ -220,7 +220,7 @@ if ( !class_exists( 'WP_GeoQuery', false ) ) {
 			$meta_value = ( array_key_exists( 'value', $meta_query ) ? $meta_query['value'] : '' );
 			$geometry = WP_GeoUtil::metaval_to_geom( $meta_value, true );
 			if ( ! empty( $geometry ) ) {
-				$new_meta_value = "{$meta_query['compare']}( meta_value,GeomFromText( %s, %d ) )";
+				$new_meta_value = "{$meta_query['compare']}( meta_value,ST_GeomFromText( %s, %d, 'axis-order=long-lat' ) )";
 				$new_meta_value = $wpdb->prepare( $new_meta_value, array( $geometry, WP_GeoUtil::get_srid() ) ); // @codingStandardsIgnoreLine
 
 				$std_query = "( $metatable.meta_key = %s AND CAST($metatable.meta_value AS $meta_type) = %s )";


### PR DESCRIPTION
As discussed in [this issue](https://github.com/BrilliantPlugins/wp-geometa/issues/17), some important MySQL functions have been renamed in MySQL 8. Tests produce:

>WordPress database error FUNCTION wordpress.GeomFromText does not exist

>WordPress database error FUNCTION wordpress.Dimension does not exist

These are depracated in [MySQl 5.7](https://dev.mysql.com/doc/refman/5.7/en/gis-wkt-functions.html#function_geomfromtext) and since removed:

>GeomFromText() and GeometryFromText() are deprecated; expect them to be removed in a future MySQL release. Use ST_GeomFromText() and ST_GeometryFromText() instead. 

>Dimension() is deprecated; expect it to be removed in a future MySQL release. Use ST_Dimension() instead. 

This PR:
- Replaces GeomFromText() with [ST_GeomFromText()](https://dev.mysql.com/doc/refman/8.0/en/gis-wkt-functions.html#function_st-geomfromtext), which also needed the [axis-order=long-lat](https://dev.mysql.com/blog-archive/axis-order-in-spatial-reference-systems/#crayon-6151ae612be4b073411414) parameter for backwards compatibility.
- Replaces Dimension() with [ST_Dimension()](https://dev.mysql.com/doc/refman/8.0/en/gis-general-property-functions.html#function_st-dimension)