### PR TITLE
Changing MySQL5 spatial function alias deprecated in MySQL8

### DIFF
--- a/sql/point_bearing_distance.sql
+++ b/sql/point_bearing_distance.sql
@@ -65,8 +65,8 @@ BEGIN
 	SET geom = wp_first_geom( p );
 
 	SET d = distance / eradius;
-	SET lat1 = RADIANS( Y(geom) );
-	SET lon1 = RADIANS( X(geom) );
+	SET lat1 = RADIANS( ST_Y(geom) );
+	SET lon1 = RADIANS( ST_X(geom) );
 	SET tc = RADIANS( bearing );
 
 	-- http://williams.best.vwh.net/avform.htm#LL


### PR DESCRIPTION
Howdy there,

I've run this lib through a tool that helps with MySQL8 compatibility and found this:

`wp_point_bearing_distance_coord_pair: FUNCTION uses removed functions Y (consider using ST_Y instead), X (consider using ST_X instead),`

Basically the `X` & `Y` functions were aliases in MySQL5 that have been deprecated in MySQL 8. You can read more about this change here: https://dev.mysql.com/blog-archive/detecting-incompatible-use-of-spatial-functions-before-upgrading-to-mysql-8-0/

Functionally nothing changes here